### PR TITLE
feat: add GHSA-9qr9-h5gf-34mp for Next.js RCE vulnerability

### DIFF
--- a/vulns/GHSA-9qr9-h5gf-34mp.json
+++ b/vulns/GHSA-9qr9-h5gf-34mp.json
@@ -3,7 +3,7 @@
   "id": "GHSA-9qr9-h5gf-34mp",
   "modified": "2025-12-04T20:07:06Z",
   "published": "2025-12-03T19:07:11Z",
-  "aliases": [
+  "upstream": [
     "CVE-2025-55182"
   ],
   "summary": "Next.js is vulnerable to RCE in React flight protocol",
@@ -168,6 +168,10 @@
     {
       "type": "PACKAGE",
       "url": "https://github.com/vercel/next.js"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://github.com/aquasecurity/trivy-db/issues/597"
     }
   ]
 }

--- a/vulns/GHSA-9qr9-h5gf-34mp.json
+++ b/vulns/GHSA-9qr9-h5gf-34mp.json
@@ -1,0 +1,173 @@
+{
+  "schema_version": "1.6.7",
+  "id": "GHSA-9qr9-h5gf-34mp",
+  "modified": "2025-12-04T20:07:06Z",
+  "published": "2025-12-03T19:07:11Z",
+  "aliases": [
+    "CVE-2025-55182"
+  ],
+  "summary": "Next.js is vulnerable to RCE in React flight protocol",
+  "details": "A vulnerability affects certain React packages for versions 19.0.0, 19.1.0, 19.1.1, and 19.2.0 and frameworks that use the affected packages, including Next.js 15.x and 16.x using the App Router. The issue is tracked upstream as CVE-2025-55182.\n\nFixed in:\nReact: 19.0.1, 19.1.2, 19.2.1\nNext.js: 15.0.5, 15.1.9, 15.2.6, 15.3.6, 15.4.8, 15.5.7, 16.0.7\n\nThe vulnerability also affects experimental canary releases starting with 14.3.0-canary.77. Users on any of the 14.3 canary builds should either downgrade to a 14.x stable release or 14.3.0-canary.76.\n\nAll users of stable 15.x or 16.x Next.js versions should upgrade to a patched, stable version immediately.\n\nThe affected React packages are:\n- react-server-dom-parcel\n- react-server-dom-turbopack\n- react-server-dom-webpack",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "next",
+        "purl": "pkg:npm/next"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "14.3.0-canary.77"
+            },
+            {
+              "fixed": "15.0.5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "next",
+        "purl": "pkg:npm/next"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "15.1.0-canary.0"
+            },
+            {
+              "fixed": "15.1.9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "next",
+        "purl": "pkg:npm/next"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "15.2.0-canary.0"
+            },
+            {
+              "fixed": "15.2.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "next",
+        "purl": "pkg:npm/next"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "15.3.0-canary.0"
+            },
+            {
+              "fixed": "15.3.6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "next",
+        "purl": "pkg:npm/next"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "15.4.0-canary.0"
+            },
+            {
+              "fixed": "15.4.8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "next",
+        "purl": "pkg:npm/next"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "15.5.0-canary.0"
+            },
+            {
+              "fixed": "15.5.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "next",
+        "purl": "pkg:npm/next"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "16.0.0-canary.0"
+            },
+            {
+              "fixed": "16.0.7"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/vercel/next.js/security/advisories/GHSA-9qr9-h5gf-34mp"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55182"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/vercel/next.js"
+    }
+  ]
+}

--- a/vulns/GHSA-9qr9-h5gf-34mp.json
+++ b/vulns/GHSA-9qr9-h5gf-34mp.json
@@ -3,7 +3,7 @@
   "id": "GHSA-9qr9-h5gf-34mp",
   "modified": "2025-12-04T20:07:06Z",
   "published": "2025-12-03T19:07:11Z",
-  "upstream": [
+  "related": [
     "CVE-2025-55182"
   ],
   "summary": "Next.js is vulnerable to RCE in React flight protocol",


### PR DESCRIPTION
## Summary
- Add vulnerability data for GHSA-9qr9-h5gf-34mp (Next.js RCE in React flight protocol)
- Use CVE-2025-55182 as the alias instead of CVE-2025-66478 which was rejected by CNA
- This enables proper vulnerability detection for affected Next.js versions

## Related Issue
Closes https://github.com/aquasecurity/trivy-db/issues/597

## Test plan
- [x] Validated with osv-linter (v1.6.7)