### PR TITLE
fix: exclude deleted files from validation

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Validate JSON
         run: |
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep .json) && : // Ignore errors
+          CHANGED_FILES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep .json) && : // Ignore errors
           if [ -n "$CHANGED_FILES" ]; then
             echo "Validating JSON files: $CHANGED_FILES"
             ## osv-linter doesn't return error code for invalid JSON. So we should handle this case.


### PR DESCRIPTION
## Summary
- Add `--diff-filter=d` option to `git diff` command to exclude deleted files from validation

Previously, the validation workflow would fail when trying to validate deleted JSON files since they no longer exist on disk.

## Test plan
- [x] Verify CI passes on this PR
- [ ] Test with a PR that deletes a JSON file